### PR TITLE
Log blog and network IDs by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ A user session covers every event recorded between opening the website and closi
   - `url`: The current page URL.
   - `hash`: The current URL hash.
   - `referer`: The page referer.
+  - `blog`: The current site URL.
+  - `network`: The current network's primary URL.
+  - `blogId`: The current blog ID.
+  - `networkId`: The current network ID.
   - `utm_campaign`: The Urchin Tracker campaign from the query string if set.
   - `utm_source`: The Urchin Tracker source from the query string if set.
   - `utm_medium`: The Urchin Tracker medium from the query string if set.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ It is recommended to use the `Altis\Analytics\Utils\query()` function for this.
 
 A user session covers every event recorded between opening the website and closing it. For every event recorded the following data is recorded depending on the scope.
 
-- `event_type`: The type of event recorded, eg. "pageView", "click", "_session.start" or "_session.stop".
+- `event_type`: The type of event recorded, eg. `pageView`, `click`, `_session.start` or `_session.stop`.
 - `event_timestamp`: The timestamp in milliseconds of when the event was recorded on the site.
 - `attributes`
   - `session`: Unique ID across all page views.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -99,6 +99,8 @@ function get_client_side_data() : array {
 	if ( is_multisite() ) {
 		$data['Attributes']['blog'] = home_url();
 		$data['Attributes']['network'] = network_home_url();
+		$data['Attributes']['blogId'] = get_current_blog_id();
+		$data['Attributes']['networkId'] = get_current_network_id();
 	}
 
 	/**


### PR DESCRIPTION
The site and network URLs can potentially change. Although rare it can be more robust to filter by ID.