### PR TITLE
Support for providing arrays in attributes and metrics

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -186,6 +186,14 @@ function enqueue_scripts() {
 		'before'
 	);
 
+	wp_add_inline_script(
+		'altis-analytics',
+		'Altis.Analytics.registerAttribute( "cheese", ["gruyere", "brie"] );' .
+		'Altis.Analytics.registerAttribute( "biscuits", function () { return ["digestives", "hobnobs", "wafers"] } );' .
+		'Altis.Analytics.registerMetric( "ratings", [ 2.0, 3.5, 7.11 ] );',
+		'after'
+	);
+
 	// Load async for performance.
 	$wp_scripts->add_data( 'altis-analytics', 'async', true );
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -186,14 +186,6 @@ function enqueue_scripts() {
 		'before'
 	);
 
-	wp_add_inline_script(
-		'altis-analytics',
-		'Altis.Analytics.registerAttribute( "cheese", ["gruyere", "brie"] );' .
-		'Altis.Analytics.registerAttribute( "biscuits", function () { return ["digestives", "hobnobs", "wafers"] } );' .
-		'Altis.Analytics.registerMetric( "ratings", [ 2.0, 3.5, 7.11 ] );',
-		'after'
-	);
-
 	// Load async for performance.
 	$wp_scripts->add_data( 'altis-analytics', 'async', true );
 

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -117,7 +117,7 @@ const prepareAttributes = async attributes => {
 };
 const prepareMetrics = async metrics => {
 	for ( const name in metrics ) {
-		metrics[ name ] = await prepareData( metrics[ name ], sanitiseMetric );
+		metrics[ name ] = await prepareData( metrics[ name ], sanitizeMetric );
 	}
 	return metrics;
 };

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -105,7 +105,7 @@ const prepareData = async ( value, sanitiseCallback ) => {
 	if ( ! Array.isArray( value ) ) {
 		value = [ value ];
 	}
-	return value.map( val => sanitiseCallback( val ) );
+	return value.map( sanitizeCallback );
 };
 const sanitiseAttribute = value => value.toString();
 const sanitiseMetric = value => parseFloat( Number( value ) );

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -109,13 +109,13 @@ const prepareData = async ( value, sanitiseCallback ) => {
 };
 const sanitiseAttribute = value => value.toString();
 const sanitiseMetric = value => parseFloat( Number( value ) );
-const prepareAttributes = async ( attributes ) => {
+const prepareAttributes = async attributes => {
 	for ( const name in attributes ) {
 		attributes[ name ] = await prepareData( attributes[ name ], sanitiseAttribute );
 	}
 	return attributes;
 };
-const prepareMetrics = async ( metrics ) => {
+const prepareMetrics = async metrics => {
 	for ( const name in metrics ) {
 		metrics[ name ] = await prepareData( metrics[ name ], sanitiseMetric );
 	}

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -102,7 +102,7 @@ const prepareData = async ( value, sanitiseCallback ) => {
 	if ( typeof value === 'function' ) {
 		value = await value();
 	}
-	if ( ! ( value instanceof Array ) ) {
+	if ( ! Array.isArray( value ) ) {
 		value = [ value ];
 	}
 	return value.map( val => sanitiseCallback( val ) );

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -110,16 +110,18 @@ const prepareData = async ( value, sanitizeCallback ) => {
 const sanitizeAttribute = value => value.toString();
 const sanitizeMetric = value => parseFloat( Number( value ) );
 const prepareAttributes = async attributes => {
+	const sanitized = {};
 	for ( const name in attributes ) {
-		attributes[ name ] = await prepareData( attributes[ name ], sanitizeAttribute );
+		sanitized[ name ] = await prepareData( attributes[ name ], sanitizeAttribute );
 	}
-	return attributes;
+	return sanitized;
 };
 const prepareMetrics = async metrics => {
+	const sanitized = {};
 	for ( const name in metrics ) {
-		metrics[ name ] = await prepareData( metrics[ name ], sanitizeMetric );
+		sanitized[ name ] = await prepareData( metrics[ name ], sanitizeMetric );
 	}
-	return metrics;
+	return sanitized;
 };
 const getAttributes = ( extra = {} ) => ( {
 	session: getSessionID(),

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -111,7 +111,7 @@ const sanitizeAttribute = value => value.toString();
 const sanitizeMetric = value => parseFloat( Number( value ) );
 const prepareAttributes = async attributes => {
 	for ( const name in attributes ) {
-		attributes[ name ] = await prepareData( attributes[ name ], sanitiseAttribute );
+		attributes[ name ] = await prepareData( attributes[ name ], sanitizeAttribute );
 	}
 	return attributes;
 };

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -107,8 +107,8 @@ const prepareData = async ( value, sanitizeCallback ) => {
 	}
 	return value.map( sanitizeCallback );
 };
-const sanitiseAttribute = value => value.toString();
-const sanitiseMetric = value => parseFloat( Number( value ) );
+const sanitizeAttribute = value => value.toString();
+const sanitizeMetric = value => parseFloat( Number( value ) );
 const prepareAttributes = async attributes => {
 	for ( const name in attributes ) {
 		attributes[ name ] = await prepareData( attributes[ name ], sanitiseAttribute );

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -98,7 +98,7 @@ const getSearchParams = () =>
 		} ),
 		{}
 	);
-const prepareData = async ( value, sanitiseCallback ) => {
+const prepareData = async ( value, sanitizeCallback ) => {
 	if ( typeof value === 'function' ) {
 		value = await value();
 	}


### PR DESCRIPTION
Both AWS Pinpoint and Elasticsearch support arrays of the required datatype
   eg string or floats for attributes and metrics respectively. We were
   previsouly sanitising these to individual numbers and strings.

   The benefit of having array values for these means that rather than using
   attribute keys like `category_NN` where `NN` is the ID we could have an
   attribute containing all category IDs associated with the event eg.
   `category_ids: [1,2,3]`.

   Elasticsearch queries are unaffected by this change in the shape of the
   data as it does not differentiate between arrays and single values, only
   the data type is important.

   Fixes #46