### PR TITLE
Make audience settings available client side

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This plugin integrates WordPress with [AWS Pinpoint](#) and provides an extensib
 
 Once installed the plugin will queue up an analytics tracker script that provides a few client side functions you can use:
 
+#### Updating Data
+
 **`Altis.Analytics.updateEndpoint( data <object> )`**
 
 Updates the data associated with the current user. Use this to provide updated custom user attributes and metrics, a user ID, and demographic data.
@@ -32,6 +34,8 @@ Records an event. The data passed in should be an object with either or both an 
 
 Those attributes and metrics can be later queried via elasticsearch.
 
+#### Adding global attributes and metrics
+
 **`Altis.Analytics.registerAttribute( name <string>, value <string | callback> )`**
 
 Sometimes you may want to record a dynamic attribute value for all events on the page. The `registerAttribute()` allows this. If a function is passed as the value will be evaluated at the time an event recorded.
@@ -39,6 +43,31 @@ Sometimes you may want to record a dynamic attribute value for all events on the
 **`Altis.Analytics.registerMetric( name <string>, value <string | callback> )`**
 
 Similar to `registerAttribute()` above but for metrics.
+
+#### Events
+
+**`Altis.Analytics.on( event <string>, callback <callback> ) : EventListener`**
+
+Attaches and returns an event listener. The available events and their callback arguments are:
+
+- `updateEndpoint`<br />
+  Called any time the current endpoint data is updated. The callback receives the endpoint object.<br />
+  ```
+  Altis.Analytics.on( 'updateEndpoint', function ( endpoint ) {
+    console.log( endpoint.Attributes );
+  } );
+  ```
+- `record`:
+  Called any time an event is recorded. The callback receives the pinpoint event object.<br />
+  ```
+  Altis.Analytics.on( 'record', function ( event ) {
+    console.log( event.Attributes, event.event_type );
+  } );
+  ```
+
+**`Altis.Analytics.off( listener <EventListener> )`**
+
+Removes an event listener returned by `Altis.Analytics.on()`.
 
 ### Constants
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Once installed the plugin will queue up an analytics tracker script that provide
 
 Updates the data associated with the current user. Use this to provide updated custom user attributes and metrics, a user ID, and demographic data.
 
+**`Altis.Analytics.getEndpoint()`**
+
+Returns the current endpoint data object.
+
 **`Altis.Analytics.record( eventName <string> [, data <object>] )`**
 
 Records an event. The data passed in should be an object with either or both an `attributes` property and `metrics` property:
@@ -33,6 +37,14 @@ Records an event. The data passed in should be an object with either or both an 
 ```
 
 Those attributes and metrics can be later queried via elasticsearch.
+
+**`Altis.Analytics.updateAudiences()`**
+
+Synchronises the current audiences associated with the page session. You shouldn't ever need to call this manually but it is called any time `updateEndpoint()`, `registerAttribute()` or `registerMetric()` are called. You can hook into the `updateAudiences` event to respond to changes in this data.
+
+**`Altis.Analytics.getAudiences()`**
+
+Retrieves an array of the audience IDs for the current page session.
 
 #### Adding global attributes and metrics
 
@@ -54,14 +66,21 @@ Attaches and returns an event listener. The available events and their callback 
   Called any time the current endpoint data is updated. The callback receives the endpoint object.<br />
   ```
   Altis.Analytics.on( 'updateEndpoint', function ( endpoint ) {
-    console.log( endpoint.Attributes );
+    console.log( endpoint.Demographic ); // { Platform: 'Mac OS', .... }
   } );
   ```
 - `record`:
   Called any time an event is recorded. The callback receives the pinpoint event object.<br />
   ```
   Altis.Analytics.on( 'record', function ( event ) {
-    console.log( event.Attributes, event.event_type );
+    console.log( event.Attributes, event.event_type ); // { referer: '', ... }, 'pageView'
+  } );
+  ```
+- `updateAudiences`<br />
+  Called any time the audiences are updated. The callback receives an array of audience IDs.<br />
+  ```
+  Altis.Analytics.on( 'updateAudiences', function ( audiences ) {
+    console.log( audiences ); // [ 1, 2, 3, ... ]
   } );
   ```
 

--- a/inc/audiences/namespace.php
+++ b/inc/audiences/namespace.php
@@ -98,6 +98,12 @@ function register_default_event_data_maps() {
 	register_field( 'attributes.utm_campaign', __( 'UTM Campaign', 'altis-analytics' ) );
 	register_field( 'attributes.utm_source', __( 'UTM Source', 'altis-analytics' ) );
 	register_field( 'attributes.utm_medium', __( 'UTM Medium', 'altis-analytics' ) );
+
+	// Time based parameters.
+	register_field( 'metrics.hour', __( 'Hour (0 - 23)', 'altis-analytics' ) );
+	register_field( 'metrics.day', __( 'Day (1 = Sunday, 7 = Saturday)', 'altis-analytics' ) );
+	register_field( 'metrics.month', __( 'Month (1 = January)', 'altis-analytics' ) );
+	register_field( 'metrics.year', __( 'Year', 'altis-analytics' ) );
 }
 
 /**

--- a/inc/audiences/namespace.php
+++ b/inc/audiences/namespace.php
@@ -766,7 +766,7 @@ function build_audience_query( array $audience ) : array {
 }
 
 /**
- * Output audience configuration data as JSON.
+ * Returns audience configuration data array for client side use.
  *
  * @return array
  */
@@ -785,20 +785,23 @@ function get_audience_config() : array {
 	 * @param int $limit The number of audiences to fetch for use client side.
 	 */
 	$limit = apply_filters( 'altis.analytics.audiences.limit', 20 );
+
+	// Prevent negative values, -1 in this case means an unbounded query.
 	$limit = absint( $limit );
 
 	$audiences = new WP_Query( [
+		'fields' => 'ids',
+		'no_found_rows' => true,
+		'order' => 'ASC',
+		'orderby' => 'menu_order',
+		'post_status' => 'publish',
 		'post_type' => POST_TYPE,
 		'posts_per_page' => $limit,
-		'post_status' => 'publish',
-		'fields' => 'ids',
-		'orderby' => 'menu_order',
-		'order' => 'ASC',
 	] );
 
 	$config = [];
 
-	// Extract the audience config from post meta.
+	// Get the audience config from post meta for each post.
 	foreach ( $audiences->posts as $audience_id ) {
 		$config[] = [
 			'id' => $audience_id,

--- a/inc/audiences/namespace.php
+++ b/inc/audiences/namespace.php
@@ -93,17 +93,6 @@ function register_default_event_data_maps() {
 	register_field( 'endpoint.Demographic.Platform', __( 'Operating system', 'altis-analytics' ) );
 	register_field( 'endpoint.Demographic.PlatformVersion', __( 'Operating system version', 'altis-analytics' ) );
 	register_field( 'endpoint.Location.Country', __( 'Country', 'altis-analytics' ) );
-
-	// UTM Campaign parameters.
-	register_field( 'attributes.utm_campaign', __( 'UTM Campaign', 'altis-analytics' ) );
-	register_field( 'attributes.utm_source', __( 'UTM Source', 'altis-analytics' ) );
-	register_field( 'attributes.utm_medium', __( 'UTM Medium', 'altis-analytics' ) );
-
-	// Time based parameters.
-	register_field( 'metrics.hour', __( 'Hour (0 - 23)', 'altis-analytics' ) );
-	register_field( 'metrics.day', __( 'Day (1 = Sunday, 7 = Saturday)', 'altis-analytics' ) );
-	register_field( 'metrics.month', __( 'Month (1 = January)', 'altis-analytics' ) );
-	register_field( 'metrics.year', __( 'Year', 'altis-analytics' ) );
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -165,8 +165,14 @@ function enqueue_scripts() {
 		'altis-analytics',
 		sprintf(
 			'var Altis = Altis || {}; Altis.Analytics = %s;' .
-			'Altis.Analytics.registerAttribute = function (key, value) { Altis.Analytics._attributes[key] = value; };' .
-			'Altis.Analytics.registerMetric = function (key, value) { Altis.Analytics._metrics[key] = value; };',
+			'Altis.Analytics.registerAttribute = function (key, value) {' .
+				'Altis.Analytics._attributes[key] = value;' .
+				'Altis.Analytics.updateAudiences && Altis.Analytics.updateAudiences();' .
+			'};' .
+			'Altis.Analytics.registerMetric = function (key, value) {' .
+				'Altis.Analytics._metrics[key] = value;' .
+				'Altis.Analytics.updateAudiences && Altis.Analytics.updateAudiences();' .
+			'};',
 			wp_json_encode(
 				[
 					'Config' => [
@@ -178,6 +184,7 @@ function enqueue_scripts() {
 						'CognitoEndpoint' => defined( 'ALTIS_ANALYTICS_COGNITO_ENDPOINT' ) ? ALTIS_ANALYTICS_COGNITO_ENDPOINT : null,
 					],
 					'Data' => (object) get_client_side_data(),
+					'Audiences' => Audiences\get_audience_config(),
 					'_attributes' => (object) [],
 					'_metrics' => (object) [],
 				]

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -16,6 +16,7 @@ const {
 	_metrics,
 	Config,
 	Data,
+	Audiences,
 } = Altis.Analytics;
 
 if ( ! Config.PinpointId || ! Config.CognitoId ) {
@@ -244,6 +245,155 @@ const Analytics = {
 
 		return await Analytics.client;
 	},
+	audiences: [],
+	updateAudiences: async () => {
+		// Take a clone of the current audiences to check if they changed later.
+		const oldAudienceIds = Analytics.audiences.slice().sort();
+
+		// Get attributes.
+		const attributes = await prepareAttributes( getAttributes() );
+		// Get metrics.
+		const metrics = await prepareMetrics( getMetrics() );
+		// Get endpoint.
+		const endpoint = Analytics.getEndpoint();
+
+		// Aggregate data into a queryable object.
+		const fieldData = {
+			attributes,
+			metrics,
+			endpoint,
+		};
+
+		// Store derived field values for quicker lookups.
+		const fieldValues = {};
+
+		// Audience ID store.
+		const audienceIds = [];
+
+		// Map audience configurations to IDs.
+		for ( const aid in Audiences ) {
+			const { id, config } = Audiences[ aid ];
+
+			// Set to true if we need match all groups.
+			// - If any rule fails we set this to false and break.
+			// Set to false if we want to match any group.
+			// - If any rule passes we set this to true and break.
+			let audienceMatched = config.include === 'all';
+
+			for ( const gid in config.groups ) {
+				const group = config.groups[ gid ];
+
+				// Set to true if we need match all rules.
+				// - If any rule fails we set this to false and break.
+				// Set to false if we want to match any rule.
+				// - If any rule passes we set this to true and break.
+				let groupMatched = group.include === 'all';
+
+				for ( const rid in group.rules ) {
+					const { field, operator, value } = group.rules[ rid ];
+
+					// Track whether the rule matches.
+					let ruleMatch = false;
+
+					// Find the field value via dot notation.
+					let currentValues = fieldValues[ field ] ||
+						field.split( '.' ).reduce( ( carry, prop ) => {
+							return carry[ prop ] ?? null;
+						}, fieldData );
+
+					// Compat for non array values like endpoint.Demographic properties.
+					if ( ! Array.isArray( currentValues ) ) {
+						currentValues = [ currentValues ];
+					}
+
+					fieldValues[ field ] = currentValues;
+
+					// Compare values.
+					for ( const vid in currentValues ) {
+						const currentValue = currentValues[ vid ];
+
+						if ( operator === '=' ) {
+							ruleMatch = currentValue === value;
+						}
+						if ( operator === '!=' ) {
+							ruleMatch = currentValue !== value;
+						}
+						if ( operator === '*=' ) {
+							ruleMatch = currentValue.indexOf( value ) > -1;
+						}
+						if ( operator === '!*' ) {
+							ruleMatch = currentValue.indexOf( value ) === -1;
+						}
+						if ( operator === '^=' ) {
+							ruleMatch = currentValue.indexOf( value ) === 0;
+						}
+
+						// Don't compare numeric values against `null`.
+						if ( value === null ) {
+							break;
+						}
+
+						if ( operator === 'gte' ) {
+							ruleMatch = Number( currentValue ) >= Number( value );
+						}
+						if ( operator === 'lte' ) {
+							ruleMatch = Number( currentValue ) <= Number( value );
+						}
+						if ( operator === 'gt' ) {
+							ruleMatch = Number( currentValue ) > Number( value );
+						}
+						if ( operator === 'lt' ) {
+							ruleMatch = Number( currentValue ) < Number( value );
+						}
+
+						// Elasticsearch will match any value stored against a key so if ruleMatch
+						// is already true we don't want to reset it.
+						if ( ruleMatch ) {
+							break;
+						}
+					}
+
+					// Determine if the group matched depending on the include rule.
+					if ( group.include === 'any' && ruleMatch ) {
+						groupMatched = true;
+						break;
+					}
+					if ( group.include === 'all' && ! ruleMatch ) {
+						groupMatched = false;
+						break;
+					}
+				}
+
+				// Determine if the audience matched depending on the group include rule.
+				if ( config.include === 'any' && groupMatched ) {
+					audienceMatched = true;
+					break;
+				}
+				if ( config.include === 'all' && ! groupMatched ) {
+					audienceMatched = false;
+					break;
+				}
+			}
+
+			if ( audienceMatched ) {
+				audienceIds.push( id );
+				break;
+			}
+		}
+
+		Analytics.audiences = audienceIds;
+
+		// Trigger an event when audiences are modified.
+		if ( audienceIds.sort().toString() !== oldAudienceIds.toString() ) {
+			const updateAudiencesEvent = new CustomEvent( 'altis.analytics.updateAudiences', {
+				detail: audienceIds,
+			} );
+			window.dispatchEvent( updateAudiencesEvent );
+		}
+	},
+	getAudiences: () => {
+		return Analytics.audiences;
+	},
 	updateEndpoint: async ( endpoint = {} ) => {
 		return await Analytics.flushEvents( endpoint );
 	},
@@ -325,6 +475,9 @@ const Analytics = {
 			detail: endpoint,
 		} );
 		window.dispatchEvent( updateEndpointEvent );
+
+		// Update audience definitions.
+		await Analytics.updateAudiences();
 
 		return endpoint;
 	},
@@ -490,6 +643,8 @@ window.addEventListener( 'beforeunload', () => {
 // Expose userland API.
 window.Altis.Analytics.updateEndpoint = Analytics.updateEndpoint;
 window.Altis.Analytics.getEndpoint = Analytics.getEndpoint;
+window.Altis.Analytics.updateAudiences = Analytics.updateAudiences;
+window.Altis.Analytics.getAudiences = Analytics.getAudiences;
 window.Altis.Analytics.on = Analytics.on;
 window.Altis.Analytics.off = Analytics.off;
 window.Altis.Analytics.record = ( type, data = {}, endpoint = {} ) =>

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -142,10 +142,6 @@ const getMetrics = ( extra = {} ) => ( {
 	elapsed: elapsed + ( Date.now() - start ),
 	scrollDepthMax,
 	scrollDepthNow,
-	hour: new Date().getHours(),
-	day: new Date().getDay() + 1,
-	month: new Date().getMonth() + 1,
-	year: new Date().getFullYear(),
 	...extra,
 	...( _metrics || {} ),
 } );

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -142,6 +142,10 @@ const getMetrics = ( extra = {} ) => ( {
 	elapsed: elapsed + ( Date.now() - start ),
 	scrollDepthMax,
 	scrollDepthNow,
+	hour: new Date().getHours(),
+	day: new Date().getDay() + 1,
+	month: new Date().getMonth() + 1,
+	year: new Date().getFullYear(),
 	...extra,
 	...( _metrics || {} ),
 } );


### PR DESCRIPTION
This exposes the audience configurations and parses them based on the current global attributes, metrics and endpoint data in order to assign the current page view to an audience.

The audiences are updated any time the endpoint data is updated or `registerAttribute()` or `registerMetric()` is called in order to keep them in sync with any custom global attributes or metrics that are derived async.

If the audiences change an event is triggered that allows external code to hook in and respond to the changes.