### PR TITLE
Ignore empty fields when querying audiences

### DIFF
--- a/inc/audiences/namespace.php
+++ b/inc/audiences/namespace.php
@@ -716,6 +716,11 @@ function build_audience_query( array $audience ) : array {
 				],
 			];
 
+			// Ignore rules with an empty field.
+			if ( empty( $rule['field'] ) ) {
+				continue;
+			}
+
 			// Handle string comparisons.
 			if ( Utils\get_field_type( $rule['field'] ) === 'string' ) {
 				switch ( $rule['operator'] ) {

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -267,6 +267,11 @@ const Analytics = {
 				for ( const rid in group.rules ) {
 					const { field, operator, value } = group.rules[ rid ];
 
+					// Ignore rules with empty field names.
+					if ( field === '' ) {
+						continue;
+					}
+
 					// Track whether the rule matches.
 					let ruleMatch = false;
 


### PR DESCRIPTION
Make sure we dont try and query against empty fields, this was producing erratic and incorrect estimates during the audience building process.

Fixes #53