### PR TITLE
Remove break statement after assigning an audience

### DIFF
--- a/src/analytics.js
+++ b/src/analytics.js
@@ -357,7 +357,6 @@ const Analytics = {
 
 			if ( audienceMatched ) {
 				audienceIds.push( id );
-				break;
 			}
 		}
 


### PR DESCRIPTION
This is a dumb bug resulting in the first matching audience being assigned, a visitor can be in multiple audiences.